### PR TITLE
Add basic ratings

### DIFF
--- a/app/controllers/api/v1/dishes_controller.rb
+++ b/app/controllers/api/v1/dishes_controller.rb
@@ -30,6 +30,20 @@ module Api
 
         render json: dishes, status: 200
       end
+
+      def rate
+        dish = Dish.find(params[:id])
+        dish_rating = rating_params.merge(dish: dish)
+        rating = Rating.create(dish_rating)
+
+        render json: rating
+      end
+
+      private
+
+      def rating_params
+        params.require(:rating).permit(:score, :review)
+      end
     end
   end
 end

--- a/app/models/rating.rb
+++ b/app/models/rating.rb
@@ -1,0 +1,4 @@
+class Rating < ApplicationRecord
+  belongs_to :dish
+  validates :score, inclusion: { in: 1..5 }
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,6 +7,7 @@ Rails.application.routes.draw do
       get "dishes/entrees", to: "dishes#entrees"
       get "dishes/appetizers", to: "dishes#appetizers"
       get "dishes/desserts", to: "dishes#desserts"
+      post "dishes/:id/rate", to: "dishes#rate"
 
       resources :dishes, only: %i(index show)
     end

--- a/db/migrate/20180222043140_create_ratings.rb
+++ b/db/migrate/20180222043140_create_ratings.rb
@@ -1,0 +1,11 @@
+class CreateRatings < ActiveRecord::Migration[5.1]
+  def change
+    create_table :ratings do |t|
+      t.references :dish, foreign_key: true, null: false
+      t.integer :score, null: false
+      t.text :review
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180222025619) do
+ActiveRecord::Schema.define(version: 20180222043140) do
 
   create_table "dishes", force: :cascade do |t|
     t.integer "restaurant_id", null: false
@@ -20,6 +20,15 @@ ActiveRecord::Schema.define(version: 20180222025619) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["restaurant_id"], name: "index_dishes_on_restaurant_id"
+  end
+
+  create_table "ratings", force: :cascade do |t|
+    t.integer "dish_id", null: false
+    t.integer "score", null: false
+    t.text "review"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["dish_id"], name: "index_ratings_on_dish_id"
   end
 
   create_table "restaurants", force: :cascade do |t|

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -1,4 +1,9 @@
 FactoryBot.define do
+  factory :rating do
+    dish
+    score 1
+  end
+
   factory :dish do
     restaurant
     sequence(:name) { |n| "Something with Jackfruit" }

--- a/spec/models/rating_spec.rb
+++ b/spec/models/rating_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+RSpec.describe Rating, type: :model do
+  it "has a valid factory" do
+    expect(create(:rating)).to be_valid
+  end
+
+  describe "validations" do
+    subject { build(:rating) }
+    it "validates that the score is between 1 and 5" do
+      is_expected.not_to allow_value(10).for(:score)
+      is_expected.to allow_value(5).for(:score)
+    end
+  end
+end

--- a/spec/requests/api/v1/dishes_spec.rb
+++ b/spec/requests/api/v1/dishes_spec.rb
@@ -58,5 +58,16 @@ RSpec.describe "Dishes" do
       expect(json.size).to eq(2)
       expect(json.first["id"]).to eq(dish.id)
     end
+
+    it "can rate dishes" do
+      dish = create(:dish, :dessert)
+      rating_score = 5
+
+      post "/api/v1/dishes/#{dish.id}/rate",
+        params: { rating: { score: rating_score, review: "This was amazing!" } }
+
+      expect(response).to be_a_success
+      expect(json["score"]).to eq(rating_score)
+    end
   end
 end


### PR DESCRIPTION
* Allows a rating of 1-5 to be attached to a dish
* Allows a written review to be attached to a dish

Todo:
* Implement user login (probably w/ facebook?), attach a rating to a
user, and ensure users can only rate each dish once
* Create a separate Vote mechanism for things like Best Overall, Best Dessert, etc

It seems to me like Rating a dish is a different mechanism than Voting for a dish and those are probably separate tables. For example, I see a rating as (eventually) belonging to both a user and a dish whereas a Vote belongs to a user and possibly 
```ruby
has_one :best_overall, class_name: Dish, foreign_key: ...
has_one :best_dessert, class_name: Dish, foreign_key: ...
``` 
etc. 

For that reason, I've chosen to focus just on Ratings for now. I'll leave voting for the future when we know more about the categories. 

cc @joeyjoejoejr for 👀